### PR TITLE
Expose the mkUConsoleImage helper function

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -219,7 +219,10 @@
     in
     {
       # Export mkUConsoleSystem for users
-      lib = { inherit mkUConsoleSystem; };
+      lib = {
+        inherit mkUConsoleSystem;
+        inherit mkUConsoleImage;
+      };
 
       #
       # === Modules ===


### PR DESCRIPTION
## Summary
This will just expose the `mkUConsoleImage` in the lib, so it's possible to build an image of my custom config, so i don't have to apply my config later in the uconsole.

## Usage

### My custom flake.nix
```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
    nixos-uconsole.url = "github:wifasoi/nixos-uconsole.git?ref=expose-mkUConsoleImage"
    #only after merge of the pr you can use minline
    #nixos-uconsole.url = "github:nixos-uconsole/nixos-uconsole";
  };

  outputs = { self, nixpkgs, nixos-uconsole, ... }: {
      uconsole-img = nixos-uconsole.lib.mkUConsoleImage {
          modules = [ ./configuration.nix ];
        };
    };

    packages.aarch64-linux = {
      uconsole-img = self.nixosConfigurations.uconsole-img.config.system.build.sdImage;
    };
  };
}
```

### Build CM5 image
```bash
nix build .#packages.aarch64-linux.uconsole-img
```


## Remarks
This is my first time with nix, and maybe there is a better way to create custom image, or retrieve the helper function. If so you can close this pr.
