### PR TITLE
Fix python packaging for uc-sleep

### DIFF
--- a/pkgs/uc-sleep.nix
+++ b/pkgs/uc-sleep.nix
@@ -13,7 +13,7 @@ in
 python3.pkgs.buildPythonApplication {
   pname = "uc-sleep";
   version = "0-unstable-20251215";
-  format = "other";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "robertjakub";
@@ -22,10 +22,7 @@ python3.pkgs.buildPythonApplication {
     hash = "sha256-zJzKKENLPsgun7zGSpNLy6LPcdO55F/XeLDbAxxZpD0=";
   };
   build-system = with python3.pkgs; [setuptools];
-  #propagatedBuildInputs = with python3.pkgs; [
-  #  python-uinput
-  #  inotify-simple
-  #];
+
   preBuild = ''
     touch src/__init__.py
     cat >> src/sleep_power_control.py << EOF

--- a/pkgs/uc-sleep.nix
+++ b/pkgs/uc-sleep.nix
@@ -4,12 +4,6 @@
   fetchFromGitHub,
   ...
 }:
-let
-  python = python3.withPackages (ps: [
-    ps.python-uinput
-    ps.inotify-simple
-  ]);
-in
 python3.pkgs.buildPythonApplication {
   pname = "uc-sleep";
   version = "0-unstable-20251215";
@@ -22,6 +16,11 @@ python3.pkgs.buildPythonApplication {
     hash = "sha256-zJzKKENLPsgun7zGSpNLy6LPcdO55F/XeLDbAxxZpD0=";
   };
   build-system = with python3.pkgs; [setuptools];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    python-uinput
+    inotify-simple
+  ];
 
   preBuild = ''
     touch src/__init__.py
@@ -36,11 +35,17 @@ def main():
 
 EOF
     cat > pyproject.toml << EOF
+[project]
+name = "uc-sleep"
+version = "0.1.0"
+dependencies = [
+  "python-uinput",
+  "inotify-simple",
+]
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
-
-  dontBuild = true;
 
 [project.scripts]
 sleep_power_control = "sleep_power_control:main"

--- a/pkgs/uc-sleep.nix
+++ b/pkgs/uc-sleep.nix
@@ -21,20 +21,34 @@ python3.pkgs.buildPythonApplication {
     rev = "fb97421766eea93f55ac31d1865c47e0913cee70";
     hash = "sha256-zJzKKENLPsgun7zGSpNLy6LPcdO55F/XeLDbAxxZpD0=";
   };
+  build-system = with python3.pkgs; [setuptools];
+  #propagatedBuildInputs = with python3.pkgs; [
+  #  python-uinput
+  #  inotify-simple
+  #];
+  preBuild = ''
+    touch src/__init__.py
+    cat >> src/sleep_power_control.py << EOF
+def main():
+  pass
+
+EOF
+    cat >> src/sleep_remap_powerkey.py << EOF
+def main():
+  pass
+
+EOF
+    cat > pyproject.toml << EOF
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
   dontBuild = true;
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    echo "#!${python}/bin/python3" > $out/bin/sleep_power_control
-    cat src/sleep_power_control.py >> $out/bin/sleep_power_control
-    chmod 0555 $out/bin/sleep_power_control
-
-    echo "#!${python}/bin/python3" > $out/bin/sleep_remap_powerkey
-    cat src/sleep_remap_powerkey.py >> $out/bin/sleep_remap_powerkey
-    chmod 0555 $out/bin/sleep_remap_powerkey
-    runHook postInstall
+[project.scripts]
+sleep_power_control = "sleep_power_control:main"
+sleep_remap_powerkey = "sleep_remap_powerkey:main"
+EOF
   '';
 
   meta = {

--- a/pkgs/uc-sleep.nix
+++ b/pkgs/uc-sleep.nix
@@ -4,23 +4,28 @@
   fetchFromGitHub,
   ...
 }:
-python3.pkgs.buildPythonApplication {
+let
   pname = "uc-sleep";
-  version = "0-unstable-20251215";
+  date = "20251215";
+  rev = "fb97421766eea93f55ac31d1865c47e0913cee70";
+  hash = "sha256-zJzKKENLPsgun7zGSpNLy6LPcdO55F/XeLDbAxxZpD0=";
+  propagatedBuildInputs = with python3.pkgs; [
+    python-uinput
+    inotify-simple
+  ];
+in
+python3.pkgs.buildPythonApplication {
+  inherit pname propagatedBuildInputs;
+
+  version = "unstable-${date}";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "robertjakub";
     repo = "uConsole-sleep";
-    rev = "fb97421766eea93f55ac31d1865c47e0913cee70";
-    hash = "sha256-zJzKKENLPsgun7zGSpNLy6LPcdO55F/XeLDbAxxZpD0=";
+    inherit rev hash;
   };
-  build-system = with python3.pkgs; [setuptools];
-
-  propagatedBuildInputs = with python3.pkgs; [
-    python-uinput
-    inotify-simple
-  ];
+  build-system = with python3.pkgs; [ setuptools];
 
   preBuild = ''
     touch src/__init__.py
@@ -36,11 +41,10 @@ def main():
 EOF
     cat > pyproject.toml << EOF
 [project]
-name = "uc-sleep"
-version = "0.1.0"
+name = "${pname}"
+version = "0.0.0.dev${date}+git.${builtins.substring 0 7 rev}"
 dependencies = [
-  "python-uinput",
-  "inotify-simple",
+${lib.concatMapStringsSep "\n" (d: "  \"${d.pname}\",") propagatedBuildInputs}
 ]
 
 [build-system]


### PR DESCRIPTION
I had finally a sliver of time to test on hardware and it worked.

This pr just inject a, hope so, sane pyproject.toml when building the package and not abuse pyinstaller,

You can discard this PR if you merge the go-rewrite first.