### PR TITLE
Use default USB controller drivers

### DIFF
--- a/modules/configtxt.nix
+++ b/modules/configtxt.nix
@@ -34,11 +34,6 @@ in
     #
     cm4 = {
       options = {
-        # Disable OTG mode (we use USB host mode)
-        otg_mode = {
-          enable = false;
-        };
-
         # Overclocking settings for better performance
         # These are safe values tested on uConsole
         # Should be tweaked for the power efficiency
@@ -64,14 +59,6 @@ in
             no_sound_switch = opt false true; # option to disable sound routing
             energy_full_design_uwh = opt false "24790000"; # battery capacity in uWh
             charge_full_design_uah = opt false "6700000"; # battery capacity in uAh
-          };
-        };
-
-        # USB controller configuration
-        dwc2 = {
-          enable = true;
-          params = {
-            dr_mode = opt true "host"; # USB host mode (not gadget/OTG)
           };
         };
 


### PR DESCRIPTION
Replacing the dwc_otg driver with dwc2 prevented some USB peripherals from operating correctly with my CM4 uConsole. As a workaround to get them running, I had to re-enable the default USB controller configuration provided by the upstream nixos-raspberrypi project:

```nix
hardware.raspberry-pi.config.cm4 = {
  options.otg_mode.enable = lib.mkForce true;
  dt-overlays.dwc2.enable = lib.mkForce false;
};
```

It would be helpful to enable the more capable driver by default.