### PR TITLE
Fix bootloader options compatibility with newer nixos-raspberrypi

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,15 +67,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1767323795,
-        "narHash": "sha256-As88Bfr+XbZXSX+hB18bFvBuyzJmTf9Ub7Y3aFufP7g=",
+        "lastModified": 1773704510,
+        "narHash": "sha256-Kq0WPitNekYzouyd8ROlZb63cpSg/+Ep2XxkV0YlABU=",
         "owner": "nvmd",
         "repo": "nixos-raspberrypi",
-        "rev": "4a73dcb8fbecb99a21285cc6c8a6e314c9ffb24d",
+        "rev": "b5c77d506bed55250a4642ce6c8b395dd29ef06b",
         "type": "github"
       },
       "original": {
         "owner": "nvmd",
+        "ref": "v1.20260317.0",
         "repo": "nixos-raspberrypi",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
                 nixpkgs.hostPlatform = "aarch64-linux";
 
                 # Use the "kernel" bootloader (direct kernel boot, not u-boot)
-                boot.loader.raspberryPi.bootloader = "kernel";
+                boot.loader.raspberry-pi.bootloader = "kernel";
 
                 #
                 # === Filesystem Configuration ===
@@ -157,7 +157,7 @@
                   # Populate the boot/firmware partition with kernel, device trees, config.txt
                   # The firmwarePopulateCmd comes from nixos-raspberrypi's bootloader module
                   populateFirmwareCommands = ''
-                    ${config.boot.loader.raspberryPi.firmwarePopulateCmd} \
+                    ${config.boot.loader.raspberry-pi.firmwarePopulateCmd} \
                       -c ${config.system.build.toplevel} \
                       -f ./firmware
                   '';
@@ -166,7 +166,7 @@
                   # Creates /boot/firmware mount point and installs boot files
                   populateRootCommands = ''
                     mkdir -p ./files/boot/firmware
-                    ${config.boot.loader.raspberryPi.bootPopulateCmd} \
+                    ${config.boot.loader.raspberry-pi.bootPopulateCmd} \
                       -c ${config.system.build.toplevel} \
                       -b ./files/boot
                   '';
@@ -215,7 +215,7 @@
                     (lib.mkAliasOptionModule [ "environment" "checkConfigurationOptions" ] [ "_module" "check" ])
                   ];
                   nixpkgs.hostPlatform = "aarch64-linux";
-                  boot.loader.raspberryPi.bootloader = "kernel";
+                  boot.loader.raspberry-pi.bootloader = "kernel";
 
                   # Filesystem configuration for SD card
                   fileSystems."/" = lib.mkDefault {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
     # nvmd's nixos-raspberrypi provides Raspberry Pi support for NixOS
     # Handles bootloader, kernel, device trees, etc.
-    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi";
+    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi/v1.20260317.0";
     nixos-raspberrypi.inputs.nixpkgs.follows = "nixpkgs";
   };
 


### PR DESCRIPTION
Newer versions of nixos-raspberrypi have removed the `boot.loader.raspberryPi` options in favor of using the upstream `boot.loader.raspberry-pi` options from nixpkgs, which are now adequate for the project. nixos-uconsole will have to match this change in order to use the newest versions of nixos-raspberrypi. Making this change now may help prepare for a near-future upgrade to NixOS 26.05