### PR TITLE
Move pin of nixos-raspberrypi to 1.20260517.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,27 +67,27 @@
         ]
       },
       "locked": {
-        "lastModified": 1773704510,
-        "narHash": "sha256-Kq0WPitNekYzouyd8ROlZb63cpSg/+Ep2XxkV0YlABU=",
+        "lastModified": 1779023229,
+        "narHash": "sha256-MInilg7B/06c34SwOuGSBho4l0H1EZcmvxTkSWCs5pE=",
         "owner": "nvmd",
         "repo": "nixos-raspberrypi",
-        "rev": "b5c77d506bed55250a4642ce6c8b395dd29ef06b",
+        "rev": "06c6e3513e1ee64b651913193fc6ac38aa4963f5",
         "type": "github"
       },
       "original": {
         "owner": "nvmd",
-        "ref": "v1.20260317.0",
+        "ref": "v1.20260517.0",
         "repo": "nixos-raspberrypi",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767047869,
-        "narHash": "sha256-tzYsEzXEVa7op1LTnrLSiPGrcCY6948iD0EcNLWcmzo=",
+        "lastModified": 1779796641,
+        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89dbf01df72eb5ebe3b24a86334b12c27d68016a",
+        "rev": "25f538306313eae3927264466c70d7001dcea1df",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
     # nvmd's nixos-raspberrypi provides Raspberry Pi support for NixOS
     # Handles bootloader, kernel, device trees, etc.
-    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi/v1.20260317.0";
+    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi/v1.20260517.0";
     nixos-raspberrypi.inputs.nixpkgs.follows = "nixpkgs";
   };
 


### PR DESCRIPTION
I was having issues with my CM5 equipped uConsole screen blanking and the wifif driver causing kernel panics and so decided to try bumping the pin to nixos-raspberrypi. This actually resolved all of the issues that I was having and I've been running this setup for a few days now without issue.