### PR TITLE
panel-cwu50: add page register select and explicit DSI lane config

### DIFF
--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -20,6 +20,8 @@ let
     ./patches/0005-overlays.patch # Device tree overlays
     ./patches/0006-bcm2835-staging.patch # BCM2835 staging driver fixes
     ./patches/0007-simple-switch.patch # Audio switch support
+    ./patches/0009-panel-cwu50-page-select.patch # Ensure page 0 select in init_sequence1
+    ./patches/0010-panel-cwu50-dsi-init0.patch # Set 4-lane DSI mode via DSI_INIT0
   ];
 in
 {

--- a/modules/patches/0009-panel-cwu50-page-select.patch
+++ b/modules/patches/0009-panel-cwu50-page-select.patch
@@ -1,0 +1,9 @@
+--- a/drivers/gpu/drm/panel/panel-cwu50.c
++++ b/drivers/gpu/drm/panel/panel-cwu50.c
+@@ -20,6 +20,7 @@ static void cwu50_init_sequence(struct cwu50 *ctx)
+ 	struct mipi_dsi_device *dsi = to_mipi_dsi_device(ctx->dev);
+ 
++	dcs_write_seq(0xE0,0x00);
+ 	dcs_write_seq(0xE1,0x93);
+ 	dcs_write_seq(0xE2,0x65);
+ 	dcs_write_seq(0xE3,0xF8);

--- a/modules/patches/0010-panel-cwu50-dsi-init0.patch
+++ b/modules/patches/0010-panel-cwu50-dsi-init0.patch
@@ -1,0 +1,11 @@
+--- a/drivers/gpu/drm/panel/panel-cwu50.c
++++ b/drivers/gpu/drm/panel/panel-cwu50.c
+@@ -22,6 +22,7 @@ static void cwu50_init_sequence(struct cwu50 *ctx)
+ 	dcs_write_seq(0xE0,0x00);
+ 	dcs_write_seq(0xE1,0x93);
+ 	dcs_write_seq(0xE2,0x65);
+ 	dcs_write_seq(0xE3,0xF8);
++	dcs_write_seq(0x80,0x03);  // 4 lanes (DSI_INIT0)
+ 	dcs_write_seq(0x70,0x20);
+ 	dcs_write_seq(0x71,0x13);
+ 	dcs_write_seq(0x72,0x06);


### PR DESCRIPTION
Two correctness fixes for the CWU50 panel driver, applicable to both CM4 and CM5 platforms.

**Patch 0009** — Ensure page 0 is selected before the password unlock sequence in init_sequence1. The boot state of the extended register page selector (0xE0) is undefined after POR. Without selecting page 0, subsequent writes may target the wrong page. init_sequence2 already does this.

**Patch 0010** — Explicitly configure DSI_INIT0 (0x80) for 4-lane MIPI DSI operation. The driver already sets dsi->lanes = 4 in probe, but the panel-side register was never programmed. Already present in init_sequence2.

These patches are:
- **General correctness** — missing page select is a latent init bug on any platform
- **Non-invasive** — writing 0x03 to DSI_INIT0 confirms 4 lanes the driver already requests

Safe for both CM4 and CM5 users.