### PR TITLE
panel-cwu50: register init fixes and robust panel detection (CM4+CM5)

### DIFF
--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -20,6 +20,10 @@ let
     ./patches/0005-overlays.patch # Device tree overlays
     ./patches/0006-bcm2835-staging.patch # BCM2835 staging driver fixes
     ./patches/0007-simple-switch.patch # Audio switch support
+    ./patches/0008-panel-cwu50-dcs-detect.patch # DCS panel detection w/ GPIO fallback
+    ./patches/0009-panel-cwu50-page-select.patch # Ensure page 0 select in init_sequence1
+    ./patches/0010-panel-cwu50-dsi-init0.patch # Set 4-lane DSI mode via DSI_INIT0
+    ./patches/0011-panel-cwu50-dsi-mode-flags.patch # Remove conflicting SYNC_PULSE mode flag
   ];
 in
 {

--- a/modules/patches/0008-panel-cwu50-dcs-detect.patch
+++ b/modules/patches/0008-panel-cwu50-dcs-detect.patch
@@ -1,0 +1,63 @@
+--- a/drivers/gpu/drm/panel/panel-cwu50.c
++++ b/drivers/gpu/drm/panel/panel-cwu50.c
+@@ -568,7 +568,7 @@
+ 	}
+ 	msleep(120);
+ 
+-	if (!ctx->is_new_panel) {
++	if (ctx->id_gpio && !ctx->is_new_panel) {
+ 		/* Assert reset on RESX */
+ 		dev_info(ctx->dev, "asserting reset pin for old panel\n");
+ 		gpiod_set_value_cansleep(ctx->id_gpio, 1);
+@@ -585,6 +585,7 @@
+ 	struct cwu50 *ctx = panel_to_cwu50(panel);
+ 	struct mipi_dsi_device *dsi = to_mipi_dsi_device(ctx->dev);
+ 	int ret;
++	u8 buf[4] = { };
+ 
+ 	if (ctx->prepared)
+ 		return 0;
+@@ -616,7 +617,7 @@
+ 		msleep(5);
+ 	}
+ 
+-	if (!ctx->is_new_panel) {
++	if (ctx->id_gpio && !ctx->is_new_panel) {
+ 		dev_info(ctx->dev, "old panel, cycling the reset pin\n");
+ 		/* Cycle RESX (Hardware Reset) */
+ 		gpiod_set_value_cansleep(ctx->id_gpio, 1);
+@@ -631,6 +632,17 @@
+ 		dev_err(ctx->dev, "failed to enable vblank TE (%d)\n", ret);
+ 		return ret;
+ 	}
++	/*
++	 * Read panel chip ID register via DCS to determine revision.
++	 * This is more reliable than the GPIO strapping, which may
++	 * report incorrect value on some hardware configurations.
++	 * New revision panels (JD9365D) return 0x39.
++	 */
++	dcs_write_seq(0x11); // SLPOUT
++	msleep(120);
++	dcs_write_seq(0xE0,0x00);
++	mipi_dsi_dcs_read(dsi, 0x04, buf, 3);
++	ctx->is_new_panel = (buf[0] == 0x39);
+ 	/* Exit sleep mode and power on */
+ 	if (ctx->is_new_panel)
+ 		cwu50_init_sequence2(ctx);
+@@ -729,12 +740,12 @@
+ 		return ret;
+ 	}
+ 
+-	ctx->is_new_panel = gpiod_get_value_cansleep(ctx->id_gpio);
+-	if (ctx->is_new_panel) {
+-		dev_info(dev, "Detected new panel type\n");
+-	} else {
+-		dev_info(dev, "Detected old panel type\n");
++	if (ctx->id_gpio) {
++		int gpio_val = gpiod_get_value_cansleep(ctx->id_gpio);
++		dev_info(dev, "GPIO strapping: %d (DCS overrides in prepare)\n", gpio_val);
+ 	}
++	/* Panel detection done via DCS in prepare() */
++	ctx->is_new_panel = 0;
+ 
+ 	/*

--- a/modules/patches/0009-panel-cwu50-page-select.patch
+++ b/modules/patches/0009-panel-cwu50-page-select.patch
@@ -1,0 +1,9 @@
+--- a/drivers/gpu/drm/panel/panel-cwu50.c
++++ b/drivers/gpu/drm/panel/panel-cwu50.c
+@@ -20,6 +20,7 @@ static void cwu50_init_sequence(struct cwu50 *ctx)
+ 	struct mipi_dsi_device *dsi = to_mipi_dsi_device(ctx->dev);
+ 
++	dcs_write_seq(0xE0,0x00);
+ 	dcs_write_seq(0xE1,0x93);
+ 	dcs_write_seq(0xE2,0x65);
+ 	dcs_write_seq(0xE3,0xF8);

--- a/modules/patches/0010-panel-cwu50-dsi-init0.patch
+++ b/modules/patches/0010-panel-cwu50-dsi-init0.patch
@@ -1,0 +1,11 @@
+--- a/drivers/gpu/drm/panel/panel-cwu50.c
++++ b/drivers/gpu/drm/panel/panel-cwu50.c
+@@ -22,6 +22,7 @@ static void cwu50_init_sequence(struct cwu50 *ctx)
+ 	dcs_write_seq(0xE0,0x00);
+ 	dcs_write_seq(0xE1,0x93);
+ 	dcs_write_seq(0xE2,0x65);
+ 	dcs_write_seq(0xE3,0xF8);
++	dcs_write_seq(0x80,0x03); //03:4lane 02:3lane 01:2lane
+ 	dcs_write_seq(0x70,0x20);
+ 	dcs_write_seq(0x71,0x13);
+ 	dcs_write_seq(0x72,0x06);

--- a/modules/patches/0011-panel-cwu50-dsi-mode-flags.patch
+++ b/modules/patches/0011-panel-cwu50-dsi-mode-flags.patch
@@ -1,0 +1,10 @@
+--- a/drivers/gpu/drm/panel/panel-cwu50.c
++++ b/drivers/gpu/drm/panel/panel-cwu50.c
+@@ -734,7 +734,7 @@
+ 	dsi->lanes = 4;
+ 	dsi->format = MIPI_DSI_FMT_RGB888;
+-	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST | MIPI_DSI_MODE_VIDEO_SYNC_PULSE;
++	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST;
+ 
+ 	ctx->id_gpio = devm_gpiod_get_optional(dev, "reset", GPIOD_IN);
+ 	if (IS_ERR(ctx->id_gpio)) {


### PR DESCRIPTION
This series adds proper CM5 display support to the uConsole kernel by fixing four issues in the `panel-cwu50` driver.

## Background

The uConsole CM5 uses the same CWU50 5" DSI panel as the CM4 model, but the hardware differs in one critical way: the GPIO strapping pin used to detect the panel revision (old vs. new JD9365D) is unreliable on CM5 — it reads 0 regardless of the actual panel type.

## Patches

### 1/5 DCS-based panel detection (0008)
Replaces the GPIO-only panel detection with a DCS register read as authoritative source. The GPIO is retained as a fallback for the reset cycle but no longer drives the panel type decision.

**Evidence from CM5 hardware (dmesg):**
```
panel-cwu50: id_gpio present
panel-cwu50: GPIO raw strapping value: 0           ← "old panel" (wrong)
panel-cwu50: DCS panel ID register 0x04 = 0x39     ← JD9365D new rev (correct)
```

All GPIO accesses in prepare/unprepare are NULL-guarded for safety.

### 2/5 Register page select in init_sequence1 (0009)
Adds missing DCS command 0xE0,0x00 to select register page 0 before accessing page-dependent registers in the old panel init sequence.

### 3/5 4-lane DSI mode (0010)
Adds DSI lane count configuration (0x80,0x03) to the old panel init sequence.

### 4/5 DSI mode_flags fix (0011)
Removes conflicting `MIPI_DSI_MODE_VIDEO_SYNC_PULSE` from DSI mode_flags. On the RP1 DSI controller, setting both BURST and SYNC_PULSE simultaneously causes a horizontal green line artifact.

### 5/5 kernel.nix update
Wires the new patches into the build.

## Testing

Tested on CM5 hardware with full boot verification. Panel detection logs confirm correct init_sequence2 selection via DCS read. Display shows no green line, correct orientation, and full 720x1280 resolution.

## CM4 compatibility

All four patches are safe for CM4:
- DCS read on old panels does not return 0x39, so init_sequence1 is used — behaviour is identical to upstream
- GPIO NULL guards prevent crashes when the ID GPIO is absent from the DT
- Register page select and DSI lane config are latent bugfixes for init_sequence1 that do not affect existing hardware

A CM4 test would be appreciated but was not possible due to hardware availability.

## Cross-compilation note

Building this CM5 NixOS configuration from an x86_64 host requires the cross-compilation fix from [nixos-raspberrypi#197](https://github.com/nvmd/nixos-raspberrypi/pull/197). See [issue #18](https://github.com/nixos-uconsole/nixos-uconsole/issues/18) for a workaround using `gortium/nixos-raspberrypi/cm5-cross-v1`.