### PR TITLE
fix(release): pin build attrs to packages.aarch64-linux.minimal-cm{4,5}

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -139,7 +139,7 @@ push_kernel() {
 }
 
 echo "==> Building CM4 image..."
-nix "${NIX_FLAGS[@]}" build .#minimal-cm4 2>&1 | tee build-cm4.log
+nix "${NIX_FLAGS[@]}" build .#packages.aarch64-linux.minimal-cm4 2>&1 | tee build-cm4.log
 
 push_kernel "uconsole-cm4-minimal" "CM4"
 
@@ -150,7 +150,7 @@ CM4_IMG=$(find result/sd-image -name '*.img' -type f | head -1)
 zstd -f -T0 "$CM4_IMG" -o "$CM4_IMG_NAME"
 
 echo "==> Building CM5 image..."
-nix "${NIX_FLAGS[@]}" build .#minimal-cm5 2>&1 | tee build-cm5.log
+nix "${NIX_FLAGS[@]}" build .#packages.aarch64-linux.minimal-cm5 2>&1 | tee build-cm5.log
 
 push_kernel "uconsole-cm5-minimal" "CM5"
 


### PR DESCRIPTION
The bare `.#minimal-cm4`/`.#minimal-cm5` attrs resolve to `packages.$currentSystem.minimal-cm4`, which doesn't exist when releasing from an x86_64 build host. Pinning the full `packages.aarch64-linux.*` path forces the correct target whether the script runs on aarch64 natively or on x86_64 with binfmt cross-build.