### PR TITLE
fix(deps): pin nixos-raspberrypi back to v1.20260317.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,16 +67,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779023229,
-        "narHash": "sha256-MInilg7B/06c34SwOuGSBho4l0H1EZcmvxTkSWCs5pE=",
+        "lastModified": 1773704510,
+        "narHash": "sha256-Kq0WPitNekYzouyd8ROlZb63cpSg/+Ep2XxkV0YlABU=",
         "owner": "nvmd",
         "repo": "nixos-raspberrypi",
-        "rev": "06c6e3513e1ee64b651913193fc6ac38aa4963f5",
+        "rev": "b5c77d506bed55250a4642ce6c8b395dd29ef06b",
         "type": "github"
       },
       "original": {
         "owner": "nvmd",
-        "ref": "v1.20260517.0",
+        "ref": "v1.20260317.0",
         "repo": "nixos-raspberrypi",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
     # nvmd's nixos-raspberrypi provides Raspberry Pi support for NixOS
     # Handles bootloader, kernel, device trees, etc.
-    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi/v1.20260517.0";
+    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi/v1.20260317.0";
     nixos-raspberrypi.inputs.nixpkgs.follows = "nixpkgs";
   };
 


### PR DESCRIPTION
The bump to v1.20260517.0 (kernel 6.12.87, firmware 1.20260408) broke the uConsole CM4 display: backlight comes on but the panel stays fully black. Same kernel/firmware applies to CM5, so the regression almost certainly hits there too.

Revert the input until we can bisect the upstream regression (likely in the rpi firmware overlay-load path or vc4/DSI bring-up), so v1.1.1 can ship the release-script fixes without breaking working hardware.